### PR TITLE
fix; docker failed to run with standard_init_linux.go:228: exec user process caused: no such file or directory

### DIFF
--- a/grpc/cmd/grpcclient/Dockerfile
+++ b/grpc/cmd/grpcclient/Dockerfile
@@ -21,7 +21,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ${ROOT}
-RUN GOOS=linux go build -o $ROOT/binary ${ROOT}/cmd/grpcclient/
+RUN CGO_ENABLED=0 GOOS=linux go build -o $ROOT/binary ${ROOT}/cmd/grpcclient/
 
 
 FROM scratch as prod

--- a/grpc/cmd/grpcserver/Dockerfile
+++ b/grpc/cmd/grpcserver/Dockerfile
@@ -22,7 +22,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ${ROOT}
-RUN GOOS=linux go build -o $ROOT/binary ${ROOT}/cmd/grpcserver/
+RUN CGO_ENABLED=0 GOOS=linux go build -o $ROOT/binary ${ROOT}/cmd/grpcserver/
 
 
 FROM scratch as prod


### PR DESCRIPTION
## tl;dr;

missing `CGO_ENABLED=0` when build.

> see: https://stackoverflow.com/questions/52640304/standard-init-linux-go190-exec-user-process-caused-no-such-file-or-directory